### PR TITLE
0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - @tideline3d
 - [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
+- [Calanish](https://github.com/calanish)
 
 ### Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [@TheTuxKeeper](https://github.com/thetuxkeeper)
 - @tideline3d
 - [SimplyPrint](https://simplyprint.dk/)
+- [Andrew Beeman](https://github.com/Kiendeleo)
 
 ### Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ or manually using this URL:
 
     https://github.com/jneilliii/OctoPrint-TerminalCommandsExtended/archive/master.zip
 
+## Most Recent Changelog
+
+**[0.1.6](https://github.com/jneilliii/OctoPrint-TerminalCommandsExtended/releases/tag/0.1.6)** (11/21/2020)
+
+**Added**
+* line break option for more formatting flexibility
+* width and offset scaffolding compliant with [bootstrap 2 fluid grid system](https://getbootstrap.com/2.3.2/scaffolding.html#fluidGridSystem)
+* release channels for OctoPrint 1.5.0+ for future rc testing, similar to OctoPrint as described [here](https://community.octoprint.org/t/how-to-use-the-release-channels-to-help-test-release-candidates/402)
+
+**Updated**
+* knockout sortable library for OctoPrint 1.5.0 compatibility
+
+### [All releases](https://github.com/jneilliii/OctoPrint-TerminalCommandsExtended/releases)
+
 ## Get Help
 
 If you experience issues with this plugin or need assistance please use the issue tracker by clicking issues above.

--- a/octoprint_terminalcommandsextended/__init__.py
+++ b/octoprint_terminalcommandsextended/__init__.py
@@ -17,7 +17,7 @@ class terminalcommandsextendedPlugin(octoprint.plugin.SettingsPlugin,
 		)
 
 	def get_settings_version(self):
-		return 3
+		return 4
 
 	def on_settings_migrate(self, target, current=None):
 		if current is None or current < 1:
@@ -29,7 +29,7 @@ class terminalcommandsextendedPlugin(octoprint.plugin.SettingsPlugin,
 				command["input"] = []
 				command["message"] = ""
 				commands_new.append(command)
-			self._settings.set(["commands"],commands_new)
+			self._settings.set(["commands"], commands_new)
 
 		if current == 1:
 			commands_new = []
@@ -37,7 +37,7 @@ class terminalcommandsextendedPlugin(octoprint.plugin.SettingsPlugin,
 				if not command.get("command", False):
 					command["command"] = ""
 				commands_new.append(command)
-			self._settings.set(["commands"],commands_new)
+			self._settings.set(["commands"], commands_new)
 
 		if current == 2:
 			commands_new = []
@@ -45,7 +45,17 @@ class terminalcommandsextendedPlugin(octoprint.plugin.SettingsPlugin,
 				if not command.get("enabled_while_printing", False):
 					command["enabled_while_printing"] = False
 				commands_new.append(command)
-			self._settings.set(["commands"],commands_new)
+			self._settings.set(["commands"], commands_new)
+
+		if current <= 3:
+			commands_new = []
+			for command in self._settings.get(['commands']):
+				if not command.get("width", False):
+					command["width"] = 2
+				if not command.get("offset", False):
+					command["offset"] = 0
+				commands_new.append(command)
+			self._settings.set(["commands"], commands_new)
 
 	##~~ AssetPlugin mixin
 

--- a/octoprint_terminalcommandsextended/__init__.py
+++ b/octoprint_terminalcommandsextended/__init__.py
@@ -61,7 +61,7 @@ class terminalcommandsextendedPlugin(octoprint.plugin.SettingsPlugin,
 
 	def get_assets(self):
 		return dict(
-			js=["js/jquery-ui.min.js","js/knockout-sortable.js","js/fontawesome-iconpicker.js","js/ko.iconpicker.js","js/terminalcommandsextended.js"],
+			js=["js/jquery-ui.min.js","js/knockout-sortable.1.2.0.js","js/fontawesome-iconpicker.js","js/ko.iconpicker.js","js/terminalcommandsextended.js"],
 			css=["css/font-awesome.min.css","css/font-awesome-v4-shims.min.css","css/fontawesome-iconpicker.css","css/terminalcommandsextended.css"]
 		)
 
@@ -78,6 +78,16 @@ class terminalcommandsextendedPlugin(octoprint.plugin.SettingsPlugin,
 				user="jneilliii",
 				repo="OctoPrint-TerminalCommandsExtended",
 				current=self._plugin_version,
+				stable_branch=dict(
+					name="Stable", branch="master", comittish=["master"]
+				),
+				prerelease_branches=[
+					dict(
+						name="Release Candidate",
+						branch="rc",
+						comittish=["rc", "master"],
+					)
+				],
 
 				# update method: pip
 				pip="https://github.com/jneilliii/OctoPrint-TerminalCommandsExtended/archive/{target_version}.zip"

--- a/octoprint_terminalcommandsextended/static/js/knockout-sortable.1.2.0.js
+++ b/octoprint_terminalcommandsextended/static/js/knockout-sortable.1.2.0.js
@@ -1,0 +1,490 @@
+// knockout-sortable 1.2.0 | (c) 2019 Ryan Niemeyer |  http://www.opensource.org/licenses/mit-license
+;(function(factory) {
+    if (typeof define === "function" && define.amd) {
+        // AMD anonymous module
+        define(["knockout", "jquery", "jquery-ui/ui/widgets/sortable", "jquery-ui/ui/widgets/draggable", "jquery-ui/ui/widgets/droppable"], factory);
+    } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
+        // CommonJS module
+        var ko = require("knockout"),
+            jQuery = require("jquery");
+        require("jquery-ui/ui/widgets/sortable");
+        require("jquery-ui/ui/widgets/draggable");
+        require("jquery-ui/ui/widgets/droppable");
+        factory(ko, jQuery);
+    } else {
+        // No module loader (plain <script> tag) - put directly in global namespace
+        factory(window.ko, window.jQuery);
+    }
+})(function(ko, $) {
+    var ITEMKEY = "ko_sortItem",
+        INDEXKEY = "ko_sourceIndex",
+        LISTKEY = "ko_sortList",
+        PARENTKEY = "ko_parentList",
+        DRAGKEY = "ko_dragItem",
+        unwrap = ko.utils.unwrapObservable,
+        dataGet = ko.utils.domData.get,
+        dataSet = ko.utils.domData.set,
+        version = $.ui && $.ui.version,
+        //1.8.24 included a fix for how events were triggered in nested sortables. indexOf checks will fail if version starts with that value (0 vs. -1)
+        hasNestedSortableFix = version && version.indexOf("1.6.") && version.indexOf("1.7.") && (version.indexOf("1.8.") || version === "1.8.24");
+
+    //internal afterRender that adds meta-data to children
+    var addMetaDataAfterRender = function(elements, data) {
+        ko.utils.arrayForEach(elements, function(element) {
+            if (element.nodeType === 1) {
+                dataSet(element, ITEMKEY, data);
+                dataSet(element, PARENTKEY, dataGet(element.parentNode, LISTKEY));
+            }
+        });
+    };
+
+    //prepare the proper options for the template binding
+    var prepareTemplateOptions = function(valueAccessor, dataName) {
+        var result = {},
+            options = {},
+            actualAfterRender;
+
+        //build our options to pass to the template engine
+        if (ko.utils.peekObservable(valueAccessor()).data) {
+            options = unwrap(valueAccessor() || {});
+            result[dataName] = options.data;
+            if (options.hasOwnProperty("template")) {
+                result.name = options.template;
+            }
+        } else {
+            result[dataName] = valueAccessor();
+        }
+
+        ko.utils.arrayForEach(["afterAdd", "afterRender", "as", "beforeRemove", "includeDestroyed", "templateEngine", "templateOptions", "nodes"], function (option) {
+            if (options.hasOwnProperty(option)) {
+                result[option] = options[option];
+            } else if (ko.bindingHandlers.sortable.hasOwnProperty(option)) {
+                result[option] = ko.bindingHandlers.sortable[option];
+            }
+        });
+
+        //use an afterRender function to add meta-data
+        if (dataName === "foreach") {
+            if (result.afterRender) {
+                //wrap the existing function, if it was passed
+                actualAfterRender = result.afterRender;
+                result.afterRender = function(element, data) {
+                    addMetaDataAfterRender.call(data, element, data);
+                    actualAfterRender.call(data, element, data);
+                };
+            } else {
+                result.afterRender = addMetaDataAfterRender;
+            }
+        }
+
+        //return options to pass to the template binding
+        return result;
+    };
+
+    var updateIndexFromDestroyedItems = function(index, items) {
+        var unwrapped = unwrap(items);
+
+        if (unwrapped) {
+            for (var i = 0; i <= index; i++) {
+                //add one for every destroyed item we find before the targetIndex in the target array
+                if (unwrapped[i] && unwrap(unwrapped[i]._destroy)) {
+                    index++;
+                }
+            }
+        }
+
+        return index;
+    };
+
+    //remove problematic leading/trailing whitespace from templates
+    var stripTemplateWhitespace = function(element, name) {
+        var templateSource,
+            templateElement;
+
+        //process named templates
+        if (name) {
+            templateElement = document.getElementById(name);
+            if (templateElement) {
+                templateSource = new ko.templateSources.domElement(templateElement);
+                templateSource.text($.trim(templateSource.text()));
+            }
+        }
+        else {
+            //remove leading/trailing non-elements from anonymous templates
+            $(element).contents().each(function() {
+                if (this && this.nodeType !== 1) {
+                    element.removeChild(this);
+                }
+            });
+        }
+    };
+
+    //connect items with observableArrays
+    ko.bindingHandlers.sortable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var $element = $(element),
+                value = unwrap(valueAccessor()) || {},
+                templateOptions = prepareTemplateOptions(valueAccessor, "foreach"),
+                sortable = {},
+                startActual, updateActual;
+
+            stripTemplateWhitespace(element, templateOptions.name);
+
+            //build a new object that has the global options with overrides from the binding
+            $.extend(true, sortable, ko.bindingHandlers.sortable);
+            if (value.options && sortable.options) {
+                ko.utils.extend(sortable.options, value.options);
+                delete value.options;
+            }
+            ko.utils.extend(sortable, value);
+
+            //if allowDrop is an observable or a function, then execute it in a computed observable
+            if (sortable.connectClass && (ko.isObservable(sortable.allowDrop) || typeof sortable.allowDrop == "function")) {
+                ko.computed({
+                    read: function() {
+                        var value = unwrap(sortable.allowDrop),
+                            shouldAdd = typeof value == "function" ? value.call(this, templateOptions.foreach) : value;
+                        ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, shouldAdd);
+                    },
+                    disposeWhenNodeIsRemoved: element
+                }, this);
+            } else {
+                ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, sortable.allowDrop);
+            }
+
+            //wrap the template binding
+            ko.bindingHandlers.template.init(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+
+            //keep a reference to start/update functions that might have been passed in
+            startActual = sortable.options.start;
+            updateActual = sortable.options.update;
+
+            //ensure draggable table row cells maintain their width while dragging (unless a helper is provided)
+            if ( !sortable.options.helper ) {
+                sortable.options.helper = function(e, ui) {
+                    if (ui.is("tr")) {
+                        ui.children().each(function() {
+                            $(this).width($(this).width());
+                        });
+                    }
+                    return ui;
+                };
+            }
+
+            //initialize sortable binding after template binding has rendered in update function
+            var createTimeout = setTimeout(function() {
+                var dragItem;
+                var originalReceive = sortable.options.receive;
+
+                $element.sortable(ko.utils.extend(sortable.options, {
+                    start: function(event, ui) {
+                        //track original index
+                        var el = ui.item[0];
+                        dataSet(el, INDEXKEY, ko.utils.arrayIndexOf(ui.item.parent().children(), el));
+
+                        //make sure that fields have a chance to update model
+                        ui.item.find("input:focus").change();
+                        if (startActual) {
+                            startActual.apply(this, arguments);
+                        }
+                    },
+                    receive: function(event, ui) {
+                        //optionally apply an existing receive handler
+                        if (typeof originalReceive === "function") {
+                            originalReceive.call(this, event, ui);
+                        }
+
+                        dragItem = dataGet(ui.item[0], DRAGKEY);
+                        if (dragItem) {
+                            //copy the model item, if a clone option is provided
+                            if (dragItem.clone) {
+                                dragItem = dragItem.clone();
+                            }
+
+                            //configure a handler to potentially manipulate item before drop
+                            if (sortable.dragged) {
+                                dragItem = sortable.dragged.call(this, dragItem, event, ui) || dragItem;
+                            }
+                        }
+                    },
+                    update: function(event, ui) {
+                        var sourceParent, targetParent, sourceIndex, targetIndex, arg,
+                            el = ui.item[0],
+                            parentEl = ui.item.parent()[0],
+                            item = dataGet(el, ITEMKEY) || dragItem;
+
+                        if (!item) {
+                            $(el).remove();
+                        }
+                        dragItem = null;
+
+                        //make sure that moves only run once, as update fires on multiple containers
+                        if (item && (this === parentEl) || (!hasNestedSortableFix && $.contains(this, parentEl))) {
+                            //identify parents
+                            sourceParent = dataGet(el, PARENTKEY);
+                            sourceIndex = dataGet(el, INDEXKEY);
+                            targetParent = dataGet(el.parentNode, LISTKEY);
+                            targetIndex = ko.utils.arrayIndexOf(ui.item.parent().children(), el);
+
+                            //take destroyed items into consideration
+                            if (!templateOptions.includeDestroyed) {
+                                sourceIndex = updateIndexFromDestroyedItems(sourceIndex, sourceParent);
+                                targetIndex = updateIndexFromDestroyedItems(targetIndex, targetParent);
+                            }
+
+                            //build up args for the callbacks
+                            if (sortable.beforeMove || sortable.afterMove) {
+                                arg = {
+                                    item: item,
+                                    sourceParent: sourceParent,
+                                    sourceParentNode: sourceParent && ui.sender || el.parentNode,
+                                    sourceIndex: sourceIndex,
+                                    targetParent: targetParent,
+                                    targetIndex: targetIndex,
+                                    cancelDrop: false
+                                };
+
+                                //execute the configured callback prior to actually moving items
+                                if (sortable.beforeMove) {
+                                    sortable.beforeMove.call(this, arg, event, ui);
+                                }
+                            }
+
+                            //call cancel on the correct list, so KO can take care of DOM manipulation
+                            if (sourceParent) {
+                                $(sourceParent === targetParent ? this : ui.sender || this).sortable("cancel");
+                            }
+                            //for a draggable item just remove the element
+                            else {
+                                $(el).remove();
+                            }
+
+                            //if beforeMove told us to cancel, then we are done
+                            if (arg && arg.cancelDrop) {
+                                return;
+                            }
+
+                            //if the strategy option is unset or false, employ the order strategy involving removal and insertion of items
+                            if (!sortable.hasOwnProperty("strategyMove") || sortable.strategyMove === false) {
+                                //do the actual move
+                                if (targetIndex >= 0) {
+                                    if (sourceParent) {
+                                        sourceParent.splice(sourceIndex, 1);
+
+                                        //if using deferred updates plugin, force updates
+                                        if (ko.processAllDeferredBindingUpdates) {
+                                            ko.processAllDeferredBindingUpdates();
+                                        }
+
+                                        //if using deferred updates on knockout 3.4, force updates
+                                        if (ko.options && ko.options.deferUpdates) {
+                                            ko.tasks.runEarly();
+                                        }
+                                    }
+
+                                    targetParent.splice(targetIndex, 0, item);
+                                }
+
+                                //rendering is handled by manipulating the observableArray; ignore dropped element
+                                dataSet(el, ITEMKEY, null);
+                            }
+                            else { //employ the strategy of moving items
+                                if (targetIndex >= 0) {
+                                    if (sourceParent) {
+                                        if (sourceParent !== targetParent) {
+                                            // moving from one list to another
+
+                                            sourceParent.splice(sourceIndex, 1);
+                                            targetParent.splice(targetIndex, 0, item);
+
+                                            //rendering is handled by manipulating the observableArray; ignore dropped element
+                                            dataSet(el, ITEMKEY, null);
+                                            ui.item.remove();
+                                        }
+                                        else {
+                                            // moving within same list
+                                            var underlyingList = unwrap(sourceParent);
+
+                                            // notify 'beforeChange' subscribers
+                                            if (sourceParent.valueWillMutate) {
+                                                sourceParent.valueWillMutate();
+                                            }
+
+                                            // move from source index ...
+                                            underlyingList.splice(sourceIndex, 1);
+                                            // ... to target index
+                                            underlyingList.splice(targetIndex, 0, item);
+
+                                            // notify subscribers
+                                            if (sourceParent.valueHasMutated) {
+                                                sourceParent.valueHasMutated();
+                                            }
+                                        }
+                                    }
+                                    else {
+                                        // drop new element from outside
+                                        targetParent.splice(targetIndex, 0, item);
+
+                                        //rendering is handled by manipulating the observableArray; ignore dropped element
+                                        dataSet(el, ITEMKEY, null);
+                                        ui.item.remove();
+                                    }
+                                }
+                            }
+
+                            //if using deferred updates plugin, force updates
+                            if (ko.processAllDeferredBindingUpdates) {
+                                ko.processAllDeferredBindingUpdates();
+                            }
+
+                            //allow binding to accept a function to execute after moving the item
+                            if (sortable.afterMove) {
+                                sortable.afterMove.call(this, arg, event, ui);
+                            }
+                        }
+
+                        if (updateActual) {
+                            updateActual.apply(this, arguments);
+                        }
+                    },
+                    connectWith: sortable.connectClass ? "." + sortable.connectClass : false
+                }));
+
+                //handle enabling/disabling sorting
+                if (sortable.isEnabled !== undefined) {
+                    ko.computed({
+                        read: function() {
+                            $element.sortable(unwrap(sortable.isEnabled) ? "enable" : "disable");
+                        },
+                        disposeWhenNodeIsRemoved: element
+                    });
+                }
+            }, 0);
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                //only call destroy if sortable has been created
+                if ($element.data("ui-sortable") || $element.data("sortable")) {
+                    $element.sortable("destroy");
+                }
+
+                ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, false);
+
+                //do not create the sortable if the element has been removed from DOM
+                clearTimeout(createTimeout);
+            });
+
+            return { 'controlsDescendantBindings': true };
+        },
+        update: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var templateOptions = prepareTemplateOptions(valueAccessor, "foreach");
+
+            //attach meta-data
+            dataSet(element, LISTKEY, templateOptions.foreach);
+
+            //call template binding's update with correct options
+            ko.bindingHandlers.template.update(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        connectClass: 'ko_container',
+        allowDrop: true,
+        afterMove: null,
+        beforeMove: null,
+        options: {}
+    };
+
+    //create a draggable that is appropriate for dropping into a sortable
+    ko.bindingHandlers.draggable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var value = unwrap(valueAccessor()) || {},
+                options = value.options || {},
+                draggableOptions = ko.utils.extend({}, ko.bindingHandlers.draggable.options),
+                templateOptions = prepareTemplateOptions(valueAccessor, "data"),
+                connectClass = value.connectClass || ko.bindingHandlers.draggable.connectClass,
+                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled;
+
+            value = "data" in value ? value.data : value;
+
+            //set meta-data
+            dataSet(element, DRAGKEY, value);
+
+            //override global options with override options passed in
+            ko.utils.extend(draggableOptions, options);
+
+            //setup connection to a sortable
+            draggableOptions.connectToSortable = connectClass ? "." + connectClass : false;
+
+            //initialize draggable
+            $(element).draggable(draggableOptions);
+
+            //handle enabling/disabling sorting
+            if (isEnabled !== undefined) {
+                ko.computed({
+                    read: function() {
+                        $(element).draggable(unwrap(isEnabled) ? "enable" : "disable");
+                    },
+                    disposeWhenNodeIsRemoved: element
+                });
+            }
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                $(element).draggable("destroy");
+            });
+
+            return ko.bindingHandlers.template.init(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        update: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var templateOptions = prepareTemplateOptions(valueAccessor, "data");
+
+            return ko.bindingHandlers.template.update(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        connectClass: ko.bindingHandlers.sortable.connectClass,
+        options: {
+            helper: "clone"
+        }
+    };
+
+    // Simple Droppable Implementation
+    // binding that updates (function or observable)
+    ko.bindingHandlers.droppable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var value = unwrap(valueAccessor()) || {},
+                options = value.options || {},
+                droppableOptions = ko.utils.extend({}, ko.bindingHandlers.droppable.options),
+                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.droppable.isEnabled;
+
+            //override global options with override options passed in
+            ko.utils.extend(droppableOptions, options);
+
+            //get reference to drop method
+            value = "data" in value ? value.data : valueAccessor();
+
+            //set drop method
+            droppableOptions.drop = function(event, ui) {
+                var droppedItem = dataGet(ui.draggable[0], DRAGKEY) || dataGet(ui.draggable[0], ITEMKEY);
+                value(droppedItem);
+            };
+
+            //initialize droppable
+            $(element).droppable(droppableOptions);
+
+            //handle enabling/disabling droppable
+            if (isEnabled !== undefined) {
+                ko.computed({
+                    read: function() {
+                        $(element).droppable(unwrap(isEnabled) ? "enable": "disable");
+                    },
+                    disposeWhenNodeIsRemoved: element
+                });
+            }
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                $(element).droppable("destroy");
+            });
+        },
+        options: {
+            accept: "*"
+        }
+    };
+});

--- a/octoprint_terminalcommandsextended/static/js/terminalcommandsextended.js
+++ b/octoprint_terminalcommandsextended/static/js/terminalcommandsextended.js
@@ -11,11 +11,25 @@ $(function() {
 		self.loginStateViewModel = parameters[0];
 		self.settingsViewModel = parameters[1];
 		self.controlViewModel = parameters[2];
+		self.terminalViewModel = parameters[3];
 
 		self.selected_command = ko.observable();
 
 		self.onBeforeBinding = function(){
 			$('#control-terminal-custom').appendTo('#term');
+			self.multidimensional_array = ko.computed(function(){
+				let matrix = [[]], column_counter = 0, row_counter = 0;
+				ko.utils.arrayForEach(self.settingsViewModel.settings.plugins.terminalcommandsextended.commands(), function(item) {
+					column_counter += (parseInt(item.width()) + parseInt(item.offset()));
+					if (column_counter > 12) {
+						row_counter++;
+						column_counter = parseInt(item.width()) + parseInt(item.offset());
+						matrix[row_counter] = [];
+					}
+					matrix[row_counter].push(item);
+				});
+				return matrix;
+			});
 		};
 
 		// Custom command list functions
@@ -28,7 +42,9 @@ $(function() {
 		self.addCommand = function() {
 			self.selected_command({icon: ko.observable('fas fa-gear'), 
 									label: ko.observable(''), 
-									tooltip: ko.observable(''), 
+									tooltip: ko.observable(''),
+									width: ko.observable(3),
+									offset: ko.observable(0),
 									command: ko.observable(''), 
 									confirmation: ko.observable(false), 
 									message: ko.observable(''), 
@@ -42,6 +58,8 @@ $(function() {
 			self.selected_command({icon: ko.observable('fas fa-gear'),
 									label: ko.observable('<BR>'),
 									tooltip: ko.observable(''),
+									width: ko.observable(12),
+									offset: ko.observable(0),
 									command: ko.observable(''),
 									confirmation: ko.observable(false),
 									message: ko.observable(''),
@@ -54,6 +72,8 @@ $(function() {
 																							label: ko.observable(data.label()),
 																							tooltip: ko.observable(data.tooltip()),
 																							command: ko.observable(data.command()),
+																							width: ko.observable(data.width()),
+																							offset: ko.observable(data.offset()),
 																							confirmation: ko.observable(data.confirmation()),
 																							message: ko.observable(data.message()),
 																							input: ko.observableArray(data.input()),
@@ -116,7 +136,7 @@ $(function() {
 
 	OCTOPRINT_VIEWMODELS.push({
 		construct: terminalcommandsextendedViewModel,
-		dependencies: ["loginStateViewModel", "settingsViewModel","controlViewModel"],
+		dependencies: ["loginStateViewModel", "settingsViewModel","controlViewModel","terminalViewModel"],
 		elements: ["#control-terminal-custom","#terminalcommandsextended","#settings_plugin_terminalcommandsextended"]
 	});
 });

--- a/octoprint_terminalcommandsextended/static/js/terminalcommandsextended.js
+++ b/octoprint_terminalcommandsextended/static/js/terminalcommandsextended.js
@@ -38,6 +38,17 @@ $(function() {
 			$('#terminalCommandEditor').modal('show');
 		};
 
+		self.addBreak = function() {
+			self.selected_command({icon: ko.observable('fas fa-gear'),
+									label: ko.observable('<BR>'),
+									tooltip: ko.observable(''),
+									command: ko.observable(''),
+									confirmation: ko.observable(false),
+									message: ko.observable(''),
+									input: ko.observableArray([]),
+									enabled_while_printing: ko.observable(false)});
+			self.settingsViewModel.settings.plugins.terminalcommandsextended.commands.push(self.selected_command());
+		};
 		self.copyCommand = function(data) {
 			self.settingsViewModel.settings.plugins.terminalcommandsextended.commands.push({icon: ko.observable(data.icon()),
 																							label: ko.observable(data.label()),

--- a/octoprint_terminalcommandsextended/templates/terminalcommandsextended.jinja2
+++ b/octoprint_terminalcommandsextended/templates/terminalcommandsextended.jinja2
@@ -3,18 +3,23 @@
 
 <!-- Template for custom terminal controls -->
 <script type="text/html" id="customTerminalControls_controlTemplate">
+    <!-- ko if: $data.label() === "<BR>" -->
+		<br>
+	<!-- /ko -->
+    <!-- ko ifnot: $data.label() === "<BR>" -->
 	<!-- ko template: { name: 'customTerminalControls_controlTemplate_input', data: $data, if: $data.command().length > 0 } --><!-- /ko -->
+	<!-- /ko -->
 </script>
 
 <!-- Template for inputs -->
 <script type="text/html" id="customTerminalControls_controlTemplate_input">
-	<div class="btn-group" style="display: inline-block; margin-left: 0px; margin-bottom: 5px;">
-	<!-- ko foreach: input -->
-		<button style="cursor: default" data-bind="text: label, enable: $root.controlViewModel.isOperational() && (!$root.controlViewModel.isPrinting() || enabled_while_printing())" class="btn"></button>
-		<input type="text" class="input-mini btn active" style="cursor: text;margin-bottom: 0px;" data-bind="attr: {placeholder: label, title: value, type: (isNaN(value()) || value() == '') ? 'text' : 'number'}, value: value, enable: $root.controlViewModel.isOperational() && !$root.controlViewModel.isPrinting()">
-	<!-- /ko -->
-		<!-- ko template: { name: 'customTerminalControls_controlTemplate_command', data: $data} --><!-- /ko -->
-	</div>
+    <div class="btn-group" style="display: inline-block; margin-left: 0px; margin-bottom: 5px;">
+        <!-- ko foreach: input -->
+            <button style="cursor: default" data-bind="text: label, enable: $root.controlViewModel.isOperational() && (!$root.controlViewModel.isPrinting() || enabled_while_printing())" class="btn"></button>
+            <input type="text" class="input-mini btn active" style="cursor: text;margin-bottom: 0px;" data-bind="attr: {placeholder: label, title: value, type: (isNaN(value()) || value() == '') ? 'text' : 'number'}, value: value, enable: $root.controlViewModel.isOperational() && !$root.controlViewModel.isPrinting()">
+        <!-- /ko -->
+        <!-- ko template: { name: 'customTerminalControls_controlTemplate_command', data: $data} --><!-- /ko -->
+    </div>
 </script>
 
 <!-- Template for button -->

--- a/octoprint_terminalcommandsextended/templates/terminalcommandsextended.jinja2
+++ b/octoprint_terminalcommandsextended/templates/terminalcommandsextended.jinja2
@@ -1,19 +1,17 @@
 <!-- Container for custom terminal controls -->
-<div id="control-terminal-custom" style="clear: both; display: none; padding-top: 10px; padding-bottom: 10px;" data-bind="visible: loginStateViewModel.isUser && settingsViewModel.settings.plugins.terminalcommandsextended.commands().length > 0, template: { name: 'customTerminalControls_controlTemplate', foreach: settingsViewModel.settings.plugins.terminalcommandsextended.commands }"></div>
+<div id="control-terminal-custom" style="clear: both; display: none; padding-top: 10px; padding-bottom: 10px;" data-bind="visible: loginStateViewModel.isUser && settingsViewModel.settings.plugins.terminalcommandsextended.commands().length > 0, template: { name: 'customTerminalControls_controlTemplate', foreach: multidimensional_array }"></div>
 
 <!-- Template for custom terminal controls -->
 <script type="text/html" id="customTerminalControls_controlTemplate">
-    <!-- ko if: $data.label() === "<BR>" -->
-		<br>
-	<!-- /ko -->
-    <!-- ko ifnot: $data.label() === "<BR>" -->
-	<!-- ko template: { name: 'customTerminalControls_controlTemplate_input', data: $data, if: $data.command().length > 0 } --><!-- /ko -->
-	<!-- /ko -->
+    <div class="row-fluid" data-bind="foreach: $data">
+	<!-- ko template: { name: 'customTerminalControls_controlTemplate_divider', data: $data, if: $data.label() === "<BR>" } --><!-- /ko -->
+	<!-- ko template: { name: 'customTerminalControls_controlTemplate_input', data: $data, ifnot: $data.label() === "<BR>" } --><!-- /ko -->
+    </div>
 </script>
 
 <!-- Template for inputs -->
 <script type="text/html" id="customTerminalControls_controlTemplate_input">
-    <div class="btn-group" style="display: inline-block; margin-left: 0px; margin-bottom: 5px;">
+    <div data-bind="css: [((offset() > 0) ? 'offset'+offset() : ''), ((label() === '<BR>') ? 'row-fluid': 'span'+width())].join(' ')">
         <!-- ko foreach: input -->
             <button style="cursor: default" data-bind="text: label, enable: $root.controlViewModel.isOperational() && (!$root.controlViewModel.isPrinting() || enabled_while_printing())" class="btn"></button>
             <input type="text" class="input-mini btn active" style="cursor: text;margin-bottom: 0px;" data-bind="attr: {placeholder: label, title: value, type: (isNaN(value()) || value() == '') ? 'text' : 'number'}, value: value, enable: $root.controlViewModel.isOperational() && !$root.controlViewModel.isPrinting()">
@@ -25,4 +23,9 @@
 <!-- Template for button -->
 <script type="text/html" id="customTerminalControls_controlTemplate_command">
 	<button class="btn" data-bind="click: $root.runCustomCommand, attr: {title: (tooltip() ? tooltip : command)}, enable: $root.controlViewModel.isOperational() && (!$root.controlViewModel.isPrinting() || enabled_while_printing())"><i data-bind="css: icon"></i> <span data-bind="text: label"/></button>
+</script>
+
+<!-- Template for button -->
+<script type="text/html" id="customTerminalControls_controlTemplate_divider">
+	<div class="row-fluid" style="height: 20px;"> </div>
 </script>

--- a/octoprint_terminalcommandsextended/templates/terminalcommandsextended_settings.jinja2
+++ b/octoprint_terminalcommandsextended/templates/terminalcommandsextended_settings.jinja2
@@ -1,22 +1,22 @@
 <h4>Buttons to Add to Terminal Tab</h4>
 <div id="terminalcommandsextended_custom_commands" class="row-fluid">
 	<div class="row-fluid">
-		<div class="span10">Click on button to configure options.</div>
-		<div class="span2" style="text-align: center;"><button class="btn btn-mini" data-bind="click: addCommand" title="Add custom command button"><i class="fa fa-plus"></i> Add</button></div>
+		<div class="span8">Click on button to configure options.</div>
+		<div class="span4" style="text-align: center;"><button class="btn btn-mini" data-bind="click: addCommand" title="Add custom command button"><i class="fa fa-plus"></i> Add Button</button><button class="btn btn-mini" data-bind="click: addBreak" title="Add Line Break"><i class="fa fa-plus"></i> Add Break</button></div>
 	</div>
-	<div data-bind="sortable: { data: settingsViewModel.settings.plugins.terminalcommandsextended.commands, options: { cancel: '.unsortable', handle: '.move_command'} }" class="row-fluid">
-			<div class="btn-group" style="margin: 5px;">
-				<button type="button" class="btn" data-bind="click: $root.showEditor, attr: {title: (tooltip() ? tooltip : command)}"><i class="fa-lg" data-bind="css: icon"></i> <span data-bind="text: label"></span></button>
-				<button type="button" class="btn btn-mini move_command" title="Move button">
-					<i class="fa fa-arrows"></i>
-				</button>
-				<button type="button" class="btn btn-mini copy_command" data-bind="click: $parent.copyCommand" title="Copy button">
-					<i class="fa fa-copy"></i>
-				</button>
-				<button type="button" class="btn btn-mini btn-danger removeJob" data-bind="click: $parent.removeCommand" title="Delete button">
-					<i class="fa fa-times"></i>
-				</button>
-			</div>
+	<div data-bind="sortable: { data: settingsViewModel.settings.plugins.terminalcommandsextended.commands, options: { cancel: '.unsortable', handle: '.move_command', containment: 'parent'} }" class="row-fluid">
+        <div class="btn-group" style="margin: 5px;" data-bind="css: {'row-fluid': label() === '<BR>'}">
+            <button type="button" class="btn" data-bind="visible: label() !== '<BR>', click: $root.showEditor, attr: {title: (tooltip() ? tooltip : command)}"><i class="fa-lg" data-bind="css: icon"></i> <span data-bind="text: label"></span></button>
+            <button type="button" class="btn btn-mini move_command" title="Move button">
+                <i class="fa fa-arrows"></i>
+            </button>
+            <button type="button" class="btn btn-mini copy_command" data-bind="click: $parent.copyCommand" title="Copy button">
+                <i class="fa fa-copy"></i>
+            </button>
+            <button type="button" class="btn btn-mini btn-danger removeJob" data-bind="click: $parent.removeCommand" title="Delete button">
+                <i class="fa fa-times"></i>
+            </button>
+        </div>
 	</div>
 </div>
 

--- a/octoprint_terminalcommandsextended/templates/terminalcommandsextended_settings.jinja2
+++ b/octoprint_terminalcommandsextended/templates/terminalcommandsextended_settings.jinja2
@@ -4,20 +4,26 @@
 		<div class="span8">Click on button to configure options.</div>
 		<div class="span4" style="text-align: center;"><button class="btn btn-mini" data-bind="click: addCommand" title="Add custom command button"><i class="fa fa-plus"></i> Add Button</button><button class="btn btn-mini" data-bind="click: addBreak" title="Add Line Break"><i class="fa fa-plus"></i> Add Break</button></div>
 	</div>
-	<div data-bind="sortable: { data: settingsViewModel.settings.plugins.terminalcommandsextended.commands, options: { cancel: '.unsortable', handle: '.move_command', containment: 'parent'} }" class="row-fluid">
-        <div class="btn-group" style="margin: 5px;" data-bind="css: {'row-fluid': label() === '<BR>'}">
-            <button type="button" class="btn" data-bind="visible: label() !== '<BR>', click: $root.showEditor, attr: {title: (tooltip() ? tooltip : command)}"><i class="fa-lg" data-bind="css: icon"></i> <span data-bind="text: label"></span></button>
-            <button type="button" class="btn btn-mini move_command" title="Move button">
-                <i class="fa fa-arrows"></i>
-            </button>
-            <button type="button" class="btn btn-mini copy_command" data-bind="click: $parent.copyCommand" title="Copy button">
-                <i class="fa fa-copy"></i>
-            </button>
-            <button type="button" class="btn btn-mini btn-danger removeJob" data-bind="click: $parent.removeCommand" title="Delete button">
-                <i class="fa fa-times"></i>
-            </button>
+    <div class="row-fluid" data-bind="foreach: multidimensional_array">
+        <div class="row-fluid">
+        <!-- ko foreach: $data -->
+            <div data-bind="css: [((offset() > 0) ? 'offset'+offset() : ''), ((label() === '<BR>') ? 'row-fluid': 'span'+width())].join(' ')">
+                <div style="margin-bottom: 5px; margin-left: 0;" data-bind="css: ['btn-group', ((offset() > 0) ? 'offset'+offset() : ''), ((label() === '<BR>') ? 'row-fluid': 'span'+width())].join(' ')">
+                    <button type="button" class="btn" data-bind="visible: label() !== '<BR>', click: $root.showEditor, attr: {title: (tooltip() ? tooltip : command)}"><i class="fa-lg" data-bind="css: icon"></i> <span data-bind="text: label"></span></button>
+                    <button type="button" class="btn btn-mini move_command" title="Move button">
+                        <i class="fa fa-arrows"></i>
+                    </button>
+                    <button type="button" class="btn btn-mini copy_command" data-bind="click: $root.copyCommand" title="Copy button">
+                        <i class="fa fa-copy"></i>
+                    </button>
+                    <button type="button" class="btn btn-mini btn-danger removeJob" data-bind="click: $root.removeCommand" title="Delete button">
+                        <i class="fa fa-times"></i>
+                    </button>
+                </div>
+            </div>
+        <!-- /ko -->
         </div>
-	</div>
+    </div>
 </div>
 
 <div id="terminalCommandEditor" data-bind="with: selected_command" class="modal hide fade">
@@ -29,7 +35,11 @@
 		<div class="controls"><label class="control-label">{{ _('Icon') }}</label><input type="text" class="input-block-level" data-bind="value: icon, iconpicker: icon,iconpickerOptions: {hideOnSelect: true, collision: true}"/></div>
 		<div class="controls"><label class="control-label">{{ _('Label') }}</label><input type="text" class="input-block-level" data-bind="value: label"/></div>
 		<div class="controls"><label class="control-label">{{ _('Tooltip') }}</label><input type="text" class="input-block-level" data-bind="value: tooltip"/></div>
-		<div class="controls"><label class="checkbox">{{ _('Enabled While Printing') }}<input type="checkbox" data-bind="checked: enabled_while_printing" title="Prompt for Confirmation"/></label></div>
+        <div class="row-fluid">
+            <div class="span6"><div class="controls"><label class="control-label">{{ _('Width') }}</label><input type="number" min="0" class="input-block-level" data-bind="value: width"/></div></div>
+            <div class="span6"><div class="controls"><label class="control-label">{{ _('Offset') }}</label><input type="number" min="0" class="input-block-level" data-bind="value: offset"/></div></div>
+        </div>
+        <div class="controls"><label class="checkbox">{{ _('Enabled While Printing') }}<input type="checkbox" data-bind="checked: enabled_while_printing" title="Prompt for Confirmation"/></label></div>
 		<div class="controls"><label class="checkbox">{{ _('Confirm') }}<input type="checkbox" data-bind="checked: confirmation" title="Prompt for Confirmation"/></label></div>
 		<!-- ko if: confirmation -->
 		<div class="controls"><label class="control-label">{{ _('Message') }}</label><input type="text" class="input-block-level" data-bind="value: message"/></div>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_terminalcommandsextended"
 plugin_name = "Terminal Commands Extended"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.5"
+plugin_version = "0.1.6rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_terminalcommandsextended"
 plugin_name = "Terminal Commands Extended"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.6rc1"
+plugin_version = "0.1.6"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
**Added**
* line break option for more formatting flexibility
* width and offset scaffolding compliant with [bootstrap 2 fluid grid system](https://getbootstrap.com/2.3.2/scaffolding.html#fluidGridSystem)
* release channels for OctoPrint 1.5.0+ for future rc testing, similar to OctoPrint as described [here](https://community.octoprint.org/t/how-to-use-the-release-channels-to-help-test-release-candidates/402)

**Updated**
* knockout sortable library for OctoPrint 1.5.0 compatibility